### PR TITLE
Update oslat with increased functionality

### DIFF
--- a/oslat-base
+++ b/oslat-base
@@ -1,0 +1,112 @@
+#!/bin/bash
+
+function exit_error() {
+    local msg="$1"; shift
+    local code="$1"; shift
+    if [ -z "$code" ]; then
+        code=1
+    fi
+    echo '{"recipient":{"type":"all","id":"all"},"user-object":{"error": "'$msg'"}}' >msgs/tx/error
+    echo "$msg"
+    exit $code
+}
+
+function dump_runtime() {
+    echo env:
+    env
+    echo
+    echo "args: $@"
+    echo
+    echo "pwd:"
+    /bin/pwd
+    echo
+    echo "ls -alR:"
+    ls -alR
+    echo
+    echo "hostname: `hostname`"
+    echo
+    echo filesystems:
+    mount
+    echo
+    echo "ls -l /dev/hugepages"
+    /bin/ls -l /dev/hugepages
+    echo
+    echo "/proc/meminfo"
+    cat /proc/meminfo
+    echo
+    echo DPDK devices:
+    dpdk-devbind -s
+    echo
+    echo netdevs:
+    ls -l /sys/class/net
+    echo
+    echo ip a:
+    ip a
+    echo
+    echo "per-node-hugepages:"
+    for n in 0 1; do
+        path="/sys/devices/system/node/node$n/hugepages/hugepages-1048576kB"
+        echo $path
+        for i in `/bin/ls -1 $path`; do
+            echo $i:
+            cat $path/$i
+        done
+    done
+    echo "cpumask"
+    taskset -pc $$
+}
+
+function validate_label() {
+    id=`echo $RS_CS_LABEL | awk -F- '{print $2}'`
+    re='^[1-9][0-9]*$'
+    if [[ ! "$id" =~ $re ]]; then
+        exit_error "ID from label $RS_CS_LABEL must a be a positive interger"
+    fi
+}
+
+function validate_sw_prereqs() {
+    local missing=""
+    local bail=0
+    echo "Checking for SW deps"
+    bin="getopt"
+    if $bin -V >/dev/null 2>&1; then
+        echo "Found $bin"
+    else
+        bail=1
+        missing+=" $bin"
+    fi
+    if [ $bail -eq 1 ]; then
+        exit_error "Could not find bin: $missing"
+    fi
+}
+
+function disable_balance()
+{
+    local cpulist="$1"; shift
+	local cpu=""
+	local file=
+	local flags_cur=
+	for cpu in `echo ${cpulist} | sed -e 's/,/ /g'`; do
+		for file in $(find /proc/sys/kernel/sched_domain/cpu$cpu -name flags -print); do
+			flags_cur=$(cat $file)
+			flags_cur=$((flags_cur & 0xfffe))
+			echo $flags_cur > $file
+		done
+	done
+}
+
+function enable_balance()
+{
+    local cpulist="$1"; shift
+	local cpu=""
+	local file=
+	local flags_cur=
+	for cpu in `echo ${cpulist} | sed -e 's/,/ /g'`; do
+		for file in $(find /proc/sys/kernel/sched_domain/cpu$cpu -name flags -print); do
+			flags_cur=$(cat $file)
+			flags_cur=$((flags_cur | 0x1))
+			echo $flags_cur > $file
+		done
+	done
+}
+

--- a/oslat-get-runtime
+++ b/oslat-get-runtime
@@ -3,7 +3,7 @@
 # -*- mode: sh; indent-tabs-mode: nil; sh-basic-offset: 4 -*-
 
 # Only output the runtime in seconds
-runtime=300
+runtime=60
 opts=$(getopt -q -o "" --longoptions "runtime:" -n "getopt.sh" -- "$@");
 eval set -- "$opts";
 while true; do

--- a/oslat-post-process
+++ b/oslat-post-process
@@ -1,3 +1,75 @@
-#!/bin/bash
+#!/usr/bin/perl
+## -*- mode: perl; indent-tabs-mode: t; perl-indent-level: 4 -*-
+## vim: autoindent tabstop=4 shiftwidth=4 expandtab softtabstop=4 filetype=perl
 
-exit 0
+use strict;
+use warnings;
+use JSON::XS;
+use Data::Dumper;
+use Getopt::Long;
+
+my $ignore;
+
+GetOptions ("runtime=s" => \$ignore,
+            "rtprio=s" => \$ignore,
+            "no-load-balance" => \$ignore
+            );
+
+my @metrics;
+my %metric_types;
+my $primary_metric = 'polling-latency-usec';
+my %times;
+
+foreach my $i (qw(begin end)) {
+    my $file = $i . ".txt";
+    open(FH, $file) || die "Could not open " . $file;
+    $times{$i} = int (<FH> * 1000);
+    close FH;
+}
+
+
+
+my $result_file = "oslat-bin-stderrout.txt";
+if ( -e $result_file) {
+    open(FH, $result_file) || die "Could not open file " . $result_file;
+    while (<FH>) {
+        # Maximum: 13 18 5 4 5 18 17 12 8 7 4 19 5 4 19
+        if ( /Maximum:\s+(.*)$/ ) {
+            my @latencies = split(/\s+/, $1);
+            my $system_max_latency = $latencies[0];
+            for (my $i=1; $i<scalar(@latencies); $i++) {
+                if ($latencies[$i] > $system_max_latency) {
+                    $system_max_latency = $latencies[$i];
+                }
+            }
+            my %this_metric;
+            my %desc = ('source' => 'oslat',
+                        'type' => $primary_metric,
+                        'class' => 'count');
+            my %s = ('end' => $times{'end'},
+                     'begin' => $times{'begin'},
+                     'value' =>  int $system_max_latency);
+            $this_metric{'desc'} = \%desc;
+            push(@{ $this_metric{'data'} }, \%s);
+            push(@metrics, \%this_metric);
+        }
+    }
+    close(FH);
+}
+# Associate the metrics with a benchmark-period (in this case "measurement")
+my %sample;
+my @periods;
+my %period = ('name' => 'measurement');
+$sample{'rickshaw-bench-metric'}{'schema'}{'version'} = "2021.03.02";
+$period{'metrics'} = \@metrics;
+push(@periods, \%period);
+$sample{'periods'} = \@periods;
+$sample{'primary-period'} = 'measurement';
+$sample{'primary-metric'} = $primary_metric;
+if (scalar @metrics > 0) {
+    my $coder = JSON::XS->new;
+    open(JSON_FH, ">post-process-data.json") ||
+        die("Could not open file post-process-data.json for writing\n");
+    print JSON_FH $coder->encode(\%sample);
+    close JSON_FH;
+}

--- a/oslat-start
+++ b/oslat-start
@@ -4,70 +4,28 @@
 exec >oslat-client-stderrout.txt
 exec 2>&1
 
-function convert_number_range() {
-        # converts a range of cpus, like "1-3,5" to a list, like "1,2,3,5"
-        local cpu_range=$1
-        local cpus_list=""
-        local cpus=""
-        for cpus in `echo "$cpu_range" | sed -e 's/,/ /g'`; do
-                if echo "$cpus" | grep -q -- "-"; then
-                        cpus=`echo $cpus | sed -e 's/-/ /'`
-                        cpus=`seq $cpus | sed -e 's/ /,/g'`
-                fi
-                for cpu in $cpus; do
-                        cpus_list="$cpus_list,$cpu"
-                done
-        done
-        cpus_list=`echo $cpus_list | sed -e 's/^,//'`
-        echo "$cpus_list"
-}
+. /usr/bin/oslat-base || (echo "/usr/bin/oslat-base not found"; exit 1)
 
-function disable_balance()
-{
-    local cpulist="$1"; shift
-	local cpu=""
-	local file=
-	local flags_cur=
-	for cpu in `echo ${cpulist} | sed -e 's/,/ /g'`; do
-		for file in $(find /proc/sys/kernel/sched_domain/cpu$cpu -name flags -print); do
-			flags_cur=$(cat $file)
-			flags_cur=$((flags_cur & 0xfffe))
-			echo $flags_cur > $file
-		done
-	done
-}
+dump_runtime
+validate_label
+validate_sw_prereqs
 
-function enable_balance()
-{
-    local cpulist="$1"; shift
-	local cpu=""
-	local file=
-	local flags_cur=
-	for cpu in `echo ${cpulist} | sed -e 's/,/ /g'`; do
-		for file in $(find /proc/sys/kernel/sched_domain/cpu$cpu -name flags -print); do
-			flags_cur=$(cat $file)
-			flags_cur=$((flags_cur | 0x1))
-			echo $flags_cur > $file
-		done
-	done
-}
-
-echo "args: $@"
-if [ -z "$RS_CS_LABEL" ]; then
-    echo "RS_CS_LABEL is not defined, exiting"
-    exit 1
+if [ -z "${WORKLOAD_CPUS}" ]; then
+    exit_error "WORKLOAD_CPUS is not defined.  This must be defined to run oslat"
 else
-    echo "RS_CS_LABEL: $RS_CS_LABEL"
+    echo "WORKLOAD_CPUS: ${WORKLOAD_CPUS}"
 fi
-echo "hostname: `hostname`"
+if [ -z "${HK_CPUS}" ]; then
+    exit_error "HK_CPUS is not defined.  This must be defined to run oslat"
+else
+    echo "HK_CPUS: ${HK_CPUS}"
+fi
 
 no_load_balance=0
 rtprio_opt=""
-max_cpus=""
-runtime=300
-cpu_range=`cat /proc/self/status | grep Cpus_allowed_list: | cut -f 2`
+runtime=60
 
-opts=$(getopt -q -o "" --longoptions "cpu-range:,no-load-balance:,rtprio:,runtime:" -n "getopt.sh" -- "$@");
+opts=$(getopt -q -o "" --longoptions "no-load-balance:,rtprio:,runtime:" -n "getopt.sh" -- "$@");
 if [ $? -ne 0 ]; then
     printf -- "\tUnrecognized option specified\n\n"
     exit 1
@@ -91,11 +49,6 @@ while true; do
             runtime=$1
             shift;
             ;;
-        --cpu-range)
-            shift;
-            cpu_range=$1
-            shift;
-            ;;
         --)
             shift;
             break
@@ -106,32 +59,24 @@ while true; do
     esac
 done
 
-cpus=""
-cpus_list=""
-for cpus in `echo "$cpu_range" | sed -e 's/,/ /g'`; do
-        if echo "$cpus" | grep -q -- "-"; then
-                cpus=`echo $cpus | sed -e 's/-/ /'`
-                cpus=`seq $cpus | sed -e 's/ /,/g'`
-        fi
-        for cpu in $cpus; do
-                cpus_list="$cpus_list,$cpu"
-        done
-done
-cpus_list=`echo $cpus_list | sed -e s/^,//`
-
 if [ "$no_load_balance" == "1" ]; then
      disable_balance $cpus_list
 fi
 
-master_cpu=`echo $cpus_list | awk -F, '{print $1}'`
-worker_cpus=`echo $cpus_list | sed -e s/^$master_cpu,//`
+# get the first CPU from HK_CPUS to use as the oslat main thread
+cpu_main_thread=$(echo ${HK_CPUS} | awk -F, '{ print $1 }')
 
-cmd="oslat --runtime $runtime $rtprio_opt --cpu-list $worker_cpus"
-echo "Going to execute $cmd"
-$cmd
+cmd="taskset -c ${HK_CPUS} oslat --runtime ${runtime} ${rtprio_opt} --cpu-list ${WORKLOAD_CPUS} --cpu-main-thread ${cpu_main_thread}"
+echo "About to run: $cmd"
+date +%s.%N >begin.txt
+$cmd >oslat-bin-stderrout.txt 2>&1
 rc=$?
+date +%s.%N >end.txt
 
 if [ "$no_load_balance" == "1" ]; then
      enable_balance $cpus_list
 fi
-exit $rc
+
+if [ $rc -gt 0 ]; then
+    exit_error "`cat oslat-bin-stderrout.txt`"
+fi

--- a/rickshaw.json
+++ b/rickshaw.json
@@ -4,12 +4,16 @@
             "version": "2020.05.18"
         }
     },
-    "benchmark": "fio",
+    "benchmark": "oslat",
     "controller" : {
         "post-script" : "%bench-dir%/oslat-post-process"
     },
     "client" : {
         "files-from-controller": [
+            {
+                "src": "%bench-dir%/oslat-base",
+                "dest": "/usr/bin/"
+            },
             {
                 "src": "%bench-dir%/oslat-start",
                 "dest": "/usr/bin/"


### PR DESCRIPTION
- Mimic bench-cyclictest behaviors:

  - defaults to 60 second runtime

  - use similar logging for environment and error cases

  - add a similar post processing utility

  - consume HK_CPUS and WORKLOAD_CPUS environment variables rather
    than manually parsing /proc/<pid>/status