### PR TITLE
update stress-ng to version 0.14.03

### DIFF
--- a/workshop.json
+++ b/workshop.json
@@ -75,11 +75,11 @@
 	    "name": "stress-ng_src",
 	    "type": "source",
 	    "source_info": {
-		"url": "https://github.com/ColinIanKing/stress-ng/archive/refs/tags/V0.12.08.tar.gz",
-		"filename": "stress-ng-0.12.08.tar.gz",
+		"url": "https://github.com/ColinIanKing/stress-ng/archive/refs/tags/V0.14.03.tar.gz",
+		"filename": "stress-ng.tar.gz",
 		"commands": {
-		    "unpack": "tar -xzf stress-ng-0.12.08.tar.gz",
-		    "get_dir": "tar -tzf stress-ng-0.12.08.tar.gz  | head -n 1",
+		    "unpack": "tar -xzf stress-ng.tar.gz",
+		    "get_dir": "tar -tzf stress-ng.tar.gz  | head -n 1",
 		    "commands": [
 			"make",
 			"make install",


### PR DESCRIPTION
- the current version, 0.12.08, does not build on the stream9 userenv

- also change the logic so that only the stress-ng URL has to change
  and not the build steps