### PR TITLE
Add stress-ng options

### DIFF
--- a/multiplex.json
+++ b/multiplex.json
@@ -5,30 +5,39 @@
     "integer_gt_zero": {
       "description": "a whole number > 0",
       "args": [
-	 "duration"
+        "duration",
+        "network-connections",
+        "stress-ng-tiles-per-cpu"
       ],
       "vals": "^[1-9][0-9]*$"
     },
     "binary": {
       "description": "0 or 1",
       "args": [
-	 "trace-markers",
-     "trace-control",
-     "no-load-balance"
+	    "trace-markers",
+        "trace-control",
+        "no-load-balance"
       ],
-      "vals": "^[01]]$"
+      "vals": "0|1"
     },
     "rtprio": {
       "description": "priority level of the oslat process (1-99)",
       "args": [
-	 "rtprio"
+	    "rtprio"
       ],
       "vals": "^[1-9]$|^[1-9][0-9]$"
+    },
+    "yesno": {
+      "description": "yes|no",
+      "args": [
+        "sysinfo-test"
+      ],
+      "vals": "yes|no"
     },
     "onoff": {
       "description": "on|off",
       "args": [
-	 "smt"
+	    "smt"
       ],
       "vals": "on|off"
     },

--- a/oslat-server-start
+++ b/oslat-server-start
@@ -8,8 +8,10 @@ exec 2>&1
 . /usr/bin/oslat-base || (echo "/usr/bin/oslat-base not found"; exit 1)
 
 STRESS_NG_TILES_PER_CPU=1
+NETWORK_CONNECTIONS=0
+SYSINFO_TEST="no"
 
-opts=$(getopt -q -o "" --longoptions "stress-ng-tiles-per-cpu:" -n "getopt.sh" -- "$@");
+opts=$(getopt -q -o "" --longoptions "network-connections:,sysinfo-test:,stress-ng-tiles-per-cpu:" -n "getopt.sh" -- "$@");
 if [ $? -ne 0 ]; then
     printf -- "\tUnrecognized option specified\n\n"
     exit 1
@@ -20,6 +22,16 @@ while true; do
         --stress-ng-tiles-per-cpu)
             shift
             STRESS_NG_TILES_PER_CPU=$1
+            shift
+            ;;
+       --network-connections)
+            shift
+            NETWORK_CONNECTIONS=$1
+            shift
+            ;;
+       --sysinfo-test)
+            shift
+            SYSINFO_TEST=$1
             shift
             ;;
         --)
@@ -73,8 +85,14 @@ CMD+=" --malloc ${TEST_TILES}"
 CMD+=" --mmap ${TEST_TILES}"
 CMD+=" --msg ${TEST_TILES}"
 CMD+=" --stream ${TEST_TILES}"
-CMD+=" --sysinfo ${TEST_TILES}"
+if [ ${SYSINFO_TEST} == "yes" ]; then
+    #NOTE(rfolco): sysinfo - statfs /sys/firmware/efi/efivars produces SMIs
+    CMD+=" --sysinfo ${TEST_TILES}"
+fi
 CMD+=" --vm ${TEST_TILES}"
+if [ ${NETWORK_CONNECTIONS} -gt 0 ]; then
+    CMD+=" --sock ${NETWORK_CONNECTIONS} --sock-zerocopy --sock-opts sendmsg"
+fi
 CMD+=" --timeout 0"
 CMD+=" --metrics"
 CMD+=" --times"


### PR DESCRIPTION
sysinfo-test and network-connections

toggle on/off sysinfo test with yes/no and specify the number of network connections.