### PR TITLE
Include sched_attr header collision fix to rhubi9

### DIFF
--- a/workshop.json
+++ b/workshop.json
@@ -24,6 +24,16 @@
                 "rttests_src_sched",
 		"stress-ng_src"
             ]
+        },
+	{
+            "name": "rhubi9",
+            "requirements": [
+                "deps",
+                "numactl_src",
+		"rttests_patches",
+                "rttests_src_sched",
+		"stress-ng_src"
+            ]
         }
     ],
     "requirements": [


### PR DESCRIPTION
sched_attr header collision was happening on stream9 only. Now it is making rhubi9 userenv builds of rt-tests to fail. This patch expands the fix created for stream9 to the rhubi9 userenv.