### PR TITLE
fix: apply sched-headers patch for Fedora 44

### DIFF
--- a/client-workshop.json
+++ b/client-workshop.json
@@ -21,6 +21,7 @@
                 "alma10",
                 "fedora42",
                 "fedora43",
+                "fedora44",
                 "rhubi9",
                 "rhubi10",
                 "stream9",


### PR DESCRIPTION
## Summary

- Add `fedora44` to the userenv list that applies the `oslat-sched-headers.patch` during engine image build

Fedora 44 ships glibc 2.41 which defines `struct sched_attr` and `sched_setattr`/`sched_getattr`, conflicting with rt-tests v2.7's own definitions in `src/include/rt-sched.h`. The sched-headers patch guards against this redefinition and was already applied for fedora42, fedora43, alma9/10, rhubi9/10, and stream9/10 — fedora44 was simply missing from the list.

Unblocks https://github.com/perftool-incubator/rickshaw/pull/851

## Test plan
- [ ] CI builds the oslat engine image on Fedora 44 successfully
- [ ] CI runs oslat benchmark on Fedora 44

🤖 Generated with [Claude Code](https://claude.com/claude-code)