### PR TITLE
fix: quote $cpu_main_thread test and correct typo

### DIFF
--- a/oslat-client
+++ b/oslat-client
@@ -134,7 +134,7 @@ echo -e "${CMD_OUTPUT}"
 HK_CPUS=$(echo -e "${CMD_OUTPUT}" | grep "final cpus:" | awk '{ print $3 }')
 echo "HK_CPUS: ${HK_CPUS}"
 
-if [ -n $cpu_main_thread ]; then
+if [ -n "${cpu_main_thread}" ]; then
     cpu_str=""
     for cpu in $(echo $cpu_main_thread | sed -e "s/,/ /g"); do
         cpu_str+=" --cpu $cpu"

--- a/oslat-client
+++ b/oslat-client
@@ -162,7 +162,7 @@ else
 fi
 
 if [[ -z "$WORKLOAD_CPUS" ]]; then
-    echo "Ivalid WORKLOAD_CPUS: $WORKLOAD_CPUS"
+    echo "Invalid WORKLOAD_CPUS: $WORKLOAD_CPUS"
     exit 1
 fi
 


### PR DESCRIPTION
## Summary
- Fix unquoted `$cpu_main_thread` in `[ -n ]` test that made the HK_CPUS fallback dead code
- Fix "Ivalid" → "Invalid" typo in WORKLOAD_CPUS error message

Closes #85

## Test plan
- [ ] CI passes
- [ ] Verify oslat runs correctly with `--cpu-main-thread` parameter
- [ ] Verify oslat falls back to HK_CPUS when `--cpu-main-thread` is not specified

🤖 Generated with [Claude Code](https://claude.ai/claude-code)