### PR TITLE
feat: use latency class with max aggregation for polling-latency-usec

### DIFF
--- a/oslat-post-process.py
+++ b/oslat-post-process.py
@@ -52,7 +52,7 @@ def main():
                 latency_str = line.split(":", 1)[1].rsplit("(us)", 1)[0]
                 latencies = [int(x) for x in latency_str.split()]
                 system_max_latency = max(latencies)
-                desc = {"source": "oslat", "type": primary_metric, "class": "count"}
+                desc = {"source": "oslat", "type": primary_metric, "class": "latency", "default-aggregation": "max"}
                 sample = {"begin": times["begin"], "end": times["end"], "value": system_max_latency}
                 metrics.log_sample("0", desc, {}, sample)
 


### PR DESCRIPTION
## Summary
- Migrate `polling-latency-usec` from `class=count` to `class=latency` with `default-aggregation=max`
- Max aggregation ensures the highest OS scheduling jitter across engines is reported

Part of [PERFNFV-414](https://redhat.atlassian.net/browse/PERFNFV-414) / epic [PERFNFV-409](https://redhat.atlassian.net/browse/PERFNFV-409)

## Test plan
- [ ] Verify metric indexed with `class=latency` and `default-aggregation=max`

🤖 Generated with [Claude Code](https://claude.com/claude-code)